### PR TITLE
return right away on bad usage of the Acquire Operation aka requesting more 'weight' than managed .

### DIFF
--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -47,9 +47,8 @@ func (s *Weighted) Acquire(ctx context.Context, n int64) error {
 
 	if n > s.size {
 		// Don't make other Acquire calls block on one that's doomed to fail.
-		s.mu.Unlock()
-		<-ctx.Done()
-		return ctx.Err()
+		s.mu.Unlock()		
+		fmt.Errorf("You are trying to acquire(%d) more that semaphore size(%d) can managed", n, s.size)
 	}
 
 	ready := make(chan struct{})


### PR DESCRIPTION
-Returning an error without waiting for user to cancel the context 
I don't get why the semaphore waits for its client to 'cancel'  the acquire operation while we know upfront that this is destined to fail.
Moreover,  returning an error like I propose will also inform users that they are using it wrongly