### PR TITLE
Feature request: singleflight to return refcount vs shared bool

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -6,8 +6,10 @@
 // mechanism.
 package singleflight // import "golang.org/x/sync/singleflight"
 
-import "sync"
-import "sync/atomic"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // call is an in-flight or completed singleflight.Do call
 type call struct {
@@ -44,7 +46,7 @@ type Result struct {
 	Shared RefShared
 }
 
-// this encapsulates both "shared boolean" as well as actual reference counter
+// RefShared struct encapsulates both "shared boolean" as well as actual reference counter
 // callers can call RefShared.Decrement to determine when last caller is done using result, so cleanup if needed can be performed
 type RefShared struct {
 	shared   bool
@@ -105,7 +107,6 @@ func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
 	if !c.forgotten {
 		delete(g.m, key)
 	}
-	//shared := newRefShared(&c.refCount)
 	shared := RefShared{shared: c.refCount > 1, refCount: &c.refCount}
 	for _, ch := range c.chans {
 		ch <- Result{c.val, c.err, shared}

--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestDo(t *testing.T) {
 	var g Group
-	v, err, _ := g.Do("key", func() (interface{}, error) {
+	v, err, shared := g.Do("key", func() (interface{}, error) {
 		return "bar", nil
 	})
 	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
@@ -23,6 +23,12 @@ func TestDo(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("Do error = %v", err)
+	}
+	if shared.Decrement() != 0 {
+		t.Errorf("ref counter is expected to be 0")
+	}
+	if shared.Shared() {
+		t.Errorf("Do returned shared")
 	}
 }
 


### PR DESCRIPTION
### Background:
We are using singleflight to run expensive procedure that creates a temporary resource (temp file)
Our challenge - we need to determine when it is safe to cleanup this temp resource
Currently `Group.Do/DoChan` calls only return a `shared bool` indicator, but they do not surface to caller how many actual caller will be using this result.

### Proposal to consider:
Currently implementation maintains "dups int" property for each `call`, semantically it is almost exactly a "reference counter" except in case of single caller it holds value 0 instead of 1.
I propose, to slightly change signature of `Group.Do`/`DoChan`: in addition to "shared bool" also return the actual reference counter (pointer to `call.dups` ?)

This PR provides an implementation for above
In short it does 2 things:
- defines a `refShared` type and changes `Group.Do` signature to use in lace of `shared bool`
- "refactor Group.Do implement via Group.Dochan call" (commit 4eee079)
   This slightly reduces duplicated code and will prevent a race condition on computation of `shared` flag. This race condition is introduced by previous item, as calculation of `shared bool` depends on value `call.dups` and that value could get changed by caller now.

### Note
It might be easier to review this PR on per commit basis