### PR TITLE
Refcount singleflight

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -24,7 +24,7 @@ type call struct {
 	// These fields are read and written with the singleflight
 	// mutex held before the WaitGroup is done, and are read but
 	// not written after the WaitGroup is done.
-	dups  int
+	dups  int64
 	chans []chan<- Result
 }
 


### PR DESCRIPTION
### Background:
We are using singleflight to run expensive procedure that creates a temporary resource (temp file).
Our challenge - we need to determine when it is safe to cleanup this temp resource
Currently `Group.Do/DoChan` methods only return a `shared bool` indicator, but they do not surface to caller how many actual callers will be using the result.

### Proposal to consider:
Currently implementation maintains "dups int" property for each `call`, semantically it is almost exactly a "reference counter" except in case of single caller it holds value 0 instead of 1.
I propose, to introduce a new Method `DoRefCount` with signature virtually identical to one of `Do` method, except instead of `shared bool` it will be returning `refCount RefCounter`(pointer to `call.dups`), which will hold a pointer to a reference counter (pointer to `call.dups` ?)

This PR provides an implementation for above
