### PR TITLE
semaphore: unblock waiters when the front waiter cancels

### DIFF
--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -69,6 +69,7 @@ func (s *Weighted) Acquire(ctx context.Context, n int64) error {
 		default:
 			isFront := s.waiters.Front() == elem
 			s.waiters.Remove(elem)
+			// If we're at the front and there're extra tokens left, notify other waiters.
 			if isFront && s.size > s.cur {
 				s.notifyWaiters()
 			}

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -170,6 +170,7 @@ func TestLargeAcquireDoesntStarve(t *testing.T) {
 	wg.Wait()
 }
 
+// translated from https://github.com/zhiqiangxu/util/blob/master/mutex/crwmutex_test.go#L43
 func TestAllocCancelDoesntStarve(t *testing.T) {
 	sem := semaphore.NewWeighted(10)
 
@@ -194,7 +195,6 @@ func TestAllocCancelDoesntStarve(t *testing.T) {
 	go func() {
 		// try to grab a read lock, it will be queued after the Lock request
 		// but should be notified when the Lock request is canceled
-		// this doesn't happen because there's a bug in semaphore
 		err := sem.Acquire(context.Background(), 1)
 		if err != nil {
 			t.FailNow()
@@ -203,7 +203,7 @@ func TestAllocCancelDoesntStarve(t *testing.T) {
 		close(doneCh)
 	}()
 
-	// because of the bug in semaphore, doneCh is never closed
+	// doneCh should be closed if the above RLock succeeded
 	select {
 	case <-doneCh:
 	case <-time.After(time.Second):

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -169,3 +169,44 @@ func TestLargeAcquireDoesntStarve(t *testing.T) {
 	sem.Release(n)
 	wg.Wait()
 }
+
+func TestAllocCancelDoesntStarve(t *testing.T) {
+	sem := semaphore.NewWeighted(10)
+
+	// hold 1 read lock
+	sem.Acquire(context.Background(), 1)
+
+	go func() {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), time.Millisecond*300)
+		defer cancelFunc()
+		// start a write lock request that will giveup after 300ms
+		err := sem.Acquire(ctx, 10)
+		if err == nil {
+			t.FailNow()
+		}
+	}()
+
+	// sleep 100ms, long enough for the Lock request to be queued
+	time.Sleep(time.Millisecond * 100)
+
+	// this channel will be closed if the following RLock succeeded
+	doneCh := make(chan struct{})
+	go func() {
+		// try to grab a read lock, it will be queued after the Lock request
+		// but should be notified when the Lock request is canceled
+		// this doesn't happen because there's a bug in semaphore
+		err := sem.Acquire(context.Background(), 1)
+		if err != nil {
+			t.FailNow()
+		}
+		sem.Release(1)
+		close(doneCh)
+	}()
+
+	// because of the bug in semaphore, doneCh is never closed
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
When `Release`, if the remaining tokens are not enough for the front waiter, no waiters will be notified.

So if the canceled waiter is the front one, it should try to notify following waiters if there are remaining tokens.

I found this bug when implementing a cancelable rwmutex based on semaphore:

https://github.com/zhiqiangxu/util/blob/master/mutex/crwmutex.go

This bug can be verified by this test:

https://github.com/zhiqiangxu/util/blob/master/mutex/crwmutex_test.go#L43