### PR TITLE
Add recover protection to Go method

### DIFF
--- a/errgroup/errgroup_test.go
+++ b/errgroup/errgroup_test.go
@@ -174,3 +174,17 @@ func TestWithContext(t *testing.T) {
 		}
 	}
 }
+
+func TestGroup_panic(t *testing.T) {
+	g, _ := errgroup.WithContext(context.Background())
+
+	g.Go(func() error {
+		panic("Ops!!!")
+	})
+
+	if err := g.Wait(); err == nil {
+		t.Errorf("after %T.Go(func() error { panic(\"Ops!!!\") })\n"+
+			"g.Wait() = %v; want %v",
+			g, err, "a non-nil error")
+	}
+}


### PR DESCRIPTION
A Goroutine without recover protection will panic if something wrong happended, so I add recover to Go().

PTAL, thanks :)