### PR TITLE
errorgroup: fix setLimit cause goroutine leak

### DIFF
--- a/errgroup/errgroup.go
+++ b/errgroup/errgroup.go
@@ -121,12 +121,12 @@ func (g *Group) TryGo(f func() error) bool {
 //
 // The limit must not be modified while any goroutines in the group are active.
 func (g *Group) SetLimit(n int) {
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
 	if n < 0 {
 		g.sem = nil
 		return
-	}
-	if len(g.sem) != 0 {
-		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
 	}
 	g.sem = make(chan token, n)
 }


### PR DESCRIPTION
SetLimit(10)
Go(xx) //start a groutine ,g.done be called if task done
SetLimit(-1) //<-- g.sem=nil

but g.done is not atomic, if g.sem=nil  maybe  block the goroutine