### PR TITLE
x/sync/singleflight: Add lazy map init to Forget

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -204,6 +204,9 @@ func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
 // an earlier call to complete.
 func (g *Group) Forget(key string) {
 	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
 	if c, ok := g.m[key]; ok {
 		c.forgotten = true
 	}

--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -318,3 +318,8 @@ func TestPanicDoSharedByDoChan(t *testing.T) {
 		t.Errorf("Test subprocess failed, but the crash isn't caused by panicking in Do")
 	}
 }
+
+func TestForgetEarly(t *testing.T) {
+	var g Group
+	g.Forget("key") // calling Forget before Do/DoChan should not panic
+}


### PR DESCRIPTION
Forget is missing lazy map initialization. If Forget is called before
any other method it will panic.