### PR TITLE
singleflight: add per caller function

### DIFF
--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -318,3 +318,104 @@ func TestPanicDoSharedByDoChan(t *testing.T) {
 		t.Errorf("Test subprocess failed, but the crash isn't caused by panicking in Do")
 	}
 }
+
+func TestDoSharedDupSupress(t *testing.T) {
+	var g Group
+	var wg1, wg2 sync.WaitGroup
+	c := make(chan string, 1)
+	var calls int32
+	fn := func() (interface{}, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// First invocation.
+			wg1.Done()
+		}
+		v := <-c
+		c <- v // pump; make available for any future calls
+
+		time.Sleep(10 * time.Millisecond) // let more goroutines enter Do
+
+		return v, nil
+	}
+
+	const n = 10
+	wg1.Add(1)
+	for i := 0; i < n; i++ {
+		wg1.Add(1)
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			wg1.Done()
+			v, err := g.DoShared("key", fn, func(interface{}, error) {})
+			if err != nil {
+				t.Errorf("Do error: %v", err)
+				return
+			}
+			if s, _ := v.(string); s != "bar" {
+				t.Errorf("Do = %T %v; want %q", v, v, "bar")
+			}
+		}()
+	}
+	wg1.Wait()
+	// At least one goroutine is in fn now and all of them have at
+	// least reached the line before the Do.
+	c <- "bar"
+	wg2.Wait()
+	if got := atomic.LoadInt32(&calls); got <= 0 || got >= n {
+		t.Errorf("number of calls = %d; want over 0 and less than %d", got, n)
+	}
+}
+
+func TestDoSharedOthersCall(t *testing.T) {
+	var g Group
+	var wg1, wg2 sync.WaitGroup
+	c := make(chan string, 1)
+	var callsOnce int32
+	var callsOthers int32
+	onceFn := func() (interface{}, error) {
+		if atomic.AddInt32(&callsOnce, 1) == 1 {
+			// First invocation.
+			wg1.Done()
+		}
+		v := <-c
+		c <- v // pump; make available for any future calls
+
+		time.Sleep(10 * time.Millisecond) // let more goroutines enter Do
+
+		return v, nil
+	}
+
+	othersFn := func(interface{}, error) {
+		atomic.AddInt32(&callsOthers, 1)
+	}
+
+	const n = 10
+	wg1.Add(1)
+	for i := 0; i < n; i++ {
+		wg1.Add(1)
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			wg1.Done()
+			v, err := g.DoShared("key", onceFn, othersFn)
+			if err != nil {
+				t.Errorf("Do error: %v", err)
+				return
+			}
+			if s, _ := v.(string); s != "bar" {
+				t.Errorf("Do = %T %v; want %q", v, v, "bar")
+			}
+		}()
+	}
+	wg1.Wait()
+	// At least one goroutine is in fn now and all of them have at
+	// least reached the line before the Do.
+	c <- "bar"
+	wg2.Wait()
+	gotOnce := atomic.LoadInt32(&callsOnce)
+	if gotOnce <= 0 || gotOnce >= n {
+		t.Errorf("number of calls = %d; want over 0 and less than %d", gotOnce, n)
+	}
+	if gotOthers := atomic.LoadInt32(&callsOthers); gotOthers != n-gotOnce {
+		t.Errorf("number of calls = %d; want %d", gotOthers, n-gotOnce)
+	}
+}


### PR DESCRIPTION
This PR is an alternative to the proposal in #9, inspired by @bcmills' [comment](https://github.com/golang/sync/pull/9#issuecomment-572705800).

The general idea is to add a second function argument to `Do`, which is guaranteed to be called by all goroutines waiting on a singleflight _before_ the singleflighted call returns. It complements the existing function argument so that writing code that must be called in _all_ cases becomes trivial.

Some refactoring to reduce code duplication could also be done, but I wanted to get some first working version out to kickstart a discussion.
 
Names are of course up for bikeshedding.

WDYT?