### PR TITLE
feat: add multimap

### DIFF
--- a/syncmultimap/multimap.go
+++ b/syncmultimap/multimap.go
@@ -1,0 +1,119 @@
+package syncmultimap
+
+import (
+	sync "sync"
+)
+
+type MultiMapSet struct {
+	key    string
+	values []interface{}
+	mapRef *MultiMap
+	sync.RWMutex
+}
+
+func NewMultiMapSet(mapRef *MultiMap, key string) *MultiMapSet {
+	values := make([]interface{}, 0)
+	return &MultiMapSet{
+		key:    key,
+		values: values,
+		mapRef: mapRef,
+	}
+}
+
+func (s *MultiMapSet) Add(value interface{}) {
+	s.Lock()
+	defer s.Unlock()
+	s.values = append(s.values, value)
+}
+
+func (s *MultiMapSet) Remove(value interface{}) {
+	s.Lock()
+	defer s.Unlock()
+
+	// Remove the pointer from the MultiMapSet
+	for i, v := range s.values {
+		if v == value {
+			s.values = append(s.values[:i], s.values[i+1:]...)
+			return
+		}
+	}
+
+	// If the set is now empty, remove it from the map
+	if len(s.values) == 0 {
+		s.mapRef.RemoveAll(s.key)
+	}
+
+}
+
+type MultiMapRangeFn func(string, interface{}) bool
+
+func (s *MultiMapSet) Range(fn MultiMapRangeFn) {
+	s.RLock()
+	defer s.RUnlock()
+	for _, value := range s.values {
+		if !fn(s.key, value) {
+			return
+		}
+	}
+}
+
+type MultiMap struct {
+	values *sync.Map
+}
+
+func NewMultiMap() *MultiMap {
+	values := sync.Map{}
+	return &MultiMap{
+		values: &values,
+	}
+}
+
+func (m *MultiMap) Add(key string, value interface{}) {
+	// Ensure a set exists
+	multiMapSet := NewMultiMapSet(m, key)
+	multiMapSetObj, _ := m.values.LoadOrStore(key, multiMapSet)
+	multiMapSet = multiMapSetObj.(*MultiMapSet)
+
+	// Add the value to the set
+	multiMapSet.Add(value)
+
+	// Ensure the set is still stored in the map
+	// This avoids a race condition whereby the set is removed
+	// concurrently.
+	m.values.Store(key, multiMapSet)
+}
+
+func (m *MultiMap) Remove(key string, value interface{}) {
+	multiMapSetObj, ok := m.values.Load(key)
+	if !ok {
+		return
+	}
+	multiMapSet := multiMapSetObj.(*MultiMapSet)
+	multiMapSet.Remove(value)
+}
+
+func (m *MultiMap) RemoveAll(key string) {
+	m.values.Delete(key)
+}
+
+func (m *MultiMap) RangeKey(key string, fn MultiMapRangeFn) {
+	multiMapSetObj, ok := m.values.Load(key)
+	if !ok {
+		return
+	}
+	multiMapSet := multiMapSetObj.(*MultiMapSet)
+	multiMapSet.Range(fn)
+}
+
+func (m *MultiMap) RangeAll(fn MultiMapRangeFn) {
+	m.values.Range(func(_, value interface{}) bool {
+		multiMapSet := value.(*MultiMapSet)
+		multiMapSet.Range(fn)
+		return true
+	})
+}
+
+func (m *MultiMap) ContainsKey(key string) bool {
+	_, ok := m.values.Load(key)
+	return ok
+}

--- a/syncmultimap/multimap_test.go
+++ b/syncmultimap/multimap_test.go
@@ -1,0 +1,72 @@
+package syncmultimap
+
+import (
+	"testing"
+)
+
+func TestMultiMap(t *testing.T) {
+	mmap := NewMultiMap()
+
+	// Test Add
+	val1, val2, val3 := 1, 2, 3
+	mmap.Add("testKey1", val1)
+	mmap.Add("testKey1", val2)
+	mmap.Add("testKey2", val3)
+
+	// Test RangeKey
+	testKey1Sum := 0
+	mmap.RangeKey("testKey1", func(key string, v interface{}) bool {
+		if key != "testKey1" {
+			t.Errorf("Expected key to be 'testKey1', got %s", key)
+		}
+		testKey1Sum += (v).(int)
+		return true
+	})
+
+	if testKey1Sum != 3 {
+		t.Errorf("Expected sum of values for 'testKey1' to be 3, got %d", testKey1Sum)
+	}
+
+	// Test RangeAll
+	totalSum := 0
+	mmap.RangeAll(func(_ string, v interface{}) bool {
+		totalSum += (v).(int)
+		return true
+	})
+
+	if totalSum != 6 {
+		t.Errorf("Expected sum of all values to be 6, got %d", totalSum)
+	}
+
+	// Test Remove
+	mmap.Remove("testKey1", val2)
+	testKey1SumAfterRemove := 0
+	mmap.RangeKey("testKey1", func(_ string, v interface{}) bool {
+		testKey1SumAfterRemove += (v).(int)
+		return true
+	})
+
+	if testKey1SumAfterRemove != 1 {
+		t.Errorf("Expected sum of values for 'testKey1' after removal to be 1, got %d", testKey1SumAfterRemove)
+	}
+
+	// Test RemoveAll
+	mmap.RemoveAll("testKey1")
+	testKey1SumAfterRemoveAll := 0
+	mmap.RangeKey("testKey1", func(_ string, v interface{}) bool {
+		testKey1SumAfterRemoveAll += (v).(int)
+		return true
+	})
+
+	if testKey1SumAfterRemoveAll != 0 {
+		t.Errorf("Expected sum of values for 'testKey1' after removeAll to be 0, got %d", testKey1SumAfterRemoveAll)
+	}
+
+	// Test ContainsKey
+	if !mmap.ContainsKey("testKey2") {
+		t.Errorf("Expected map to contain key 'testKey2'")
+	}
+	if mmap.ContainsKey("testKey1") {
+		t.Errorf("Expected map to not contain key 'testKey1'")
+	}
+}


### PR DESCRIPTION
## What does this PR do?
This PR adds a synchronized `multimap` type to `sync`.

## Why do we need a specific primitive for `multimap`?
1. **standardization** - Libraries can more easily inter-operate if there is a standard multimap type.  [Rust](https://docs.rs/multimap/latest/multimap/) and [C++](https://en.cppreference.com/w/cpp/container/multimap) offer standard multimap implementations, demonstrating the need/demand for this type.
2. **correctness** - Implementation of `multimap` is non-trivial. Providing a standard implementation reduces the risk of bugs introduced by poor `multimap` implementations. 
3. **performance** - Although this initial implementation of `multimap` rests upon the `sync.Map` interface, we likely can consolidating to a single mutex).

## How has this been validated?
I have added some initial unit tests of this implementation. I can add additional tests/benchmarks as needed.