### PR TITLE
Yash/opt panic handler

### DIFF
--- a/errgroup/errgroup.go
+++ b/errgroup/errgroup.go
@@ -102,7 +102,7 @@ func (g *Group) TryGo(f func() error, ph ...func()) bool {
 	if g.sem != nil {
 		select {
 		case g.sem <- token{}:
-			// Note: this allows barging iff channels in general allow barging.
+			// Note: this allows barging if channels in general allow barging.
 		default:
 			return false
 		}

--- a/errgroup/errgroup.go
+++ b/errgroup/errgroup.go
@@ -17,9 +17,11 @@ import (
 
 type token struct{}
 
-// A Group is a collection of goroutines working on subtasks that are part of// the same overall task.
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
 //
-// A zero Group is valid, has no limit on the number of active goroutines,// and does not cancel on error.
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
 type Group struct {
 	cancel func(error)
 
@@ -38,7 +40,8 @@ func (g *Group) done() {
 	g.wg.Done()
 }
 
-// WithContext returns a new Group and an associated Context derived from ctx.//
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
 // The derived Context is canceled the first time a function passed to Go
 // returns a non-nil error or the first time Wait returns, whichever occurs
 // first.
@@ -47,7 +50,8 @@ func WithContext(ctx context.Context) (*Group, context.Context) {
 	return &Group{cancel: cancel}, ctx
 }
 
-// Wait blocks until all function calls from the Go method have returned, then// returns the first non-nil error (if any) from them.
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
 func (g *Group) Wait() error {
 	g.wg.Wait()
 	if g.cancel != nil {
@@ -56,7 +60,8 @@ func (g *Group) Wait() error {
 	return g.err
 }
 
-// Go calls the given function in a new goroutine.// It blocks until the new goroutine can be added without the number of
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
 // active goroutines in the group exceeding the configured limit.
 //
 // The first call to return a non-nil error cancels the group's context, if the
@@ -89,7 +94,8 @@ func (g *Group) Go(f func() error, ph ...func()) {
 	}()
 }
 
-// TryGo calls the given function in a new goroutine only if the number of// active goroutines in the group is currently below the configured limit.
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
 //
 // The return value reports whether the goroutine was started.
 func (g *Group) TryGo(f func() error, ph ...func()) bool {
@@ -126,9 +132,11 @@ func (g *Group) TryGo(f func() error, ph ...func()) bool {
 	return true
 }
 
-// SetLimit limits the number of active goroutines in this group to at most n.// A negative value indicates no limit.
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
 //
-// Any subsequent call to the Go method will block until it can add an active// goroutine without exceeding the configured limit.
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
 //
 // The limit must not be modified while any goroutines in the group are active.
 func (g *Group) SetLimit(n int) {

--- a/errgroup/errgroup.go
+++ b/errgroup/errgroup.go
@@ -17,11 +17,9 @@ import (
 
 type token struct{}
 
-// A Group is a collection of goroutines working on subtasks that are part of
-// the same overall task.
+// A Group is a collection of goroutines working on subtasks that are part of// the same overall task.
 //
-// A zero Group is valid, has no limit on the number of active goroutines,
-// and does not cancel on error.
+// A zero Group is valid, has no limit on the number of active goroutines,// and does not cancel on error.
 type Group struct {
 	cancel func(error)
 
@@ -40,8 +38,7 @@ func (g *Group) done() {
 	g.wg.Done()
 }
 
-// WithContext returns a new Group and an associated Context derived from ctx.
-//
+// WithContext returns a new Group and an associated Context derived from ctx.//
 // The derived Context is canceled the first time a function passed to Go
 // returns a non-nil error or the first time Wait returns, whichever occurs
 // first.
@@ -50,8 +47,7 @@ func WithContext(ctx context.Context) (*Group, context.Context) {
 	return &Group{cancel: cancel}, ctx
 }
 
-// Wait blocks until all function calls from the Go method have returned, then
-// returns the first non-nil error (if any) from them.
+// Wait blocks until all function calls from the Go method have returned, then// returns the first non-nil error (if any) from them.
 func (g *Group) Wait() error {
 	g.wg.Wait()
 	if g.cancel != nil {
@@ -60,19 +56,26 @@ func (g *Group) Wait() error {
 	return g.err
 }
 
-// Go calls the given function in a new goroutine.
-// It blocks until the new goroutine can be added without the number of
+// Go calls the given function in a new goroutine.// It blocks until the new goroutine can be added without the number of
 // active goroutines in the group exceeding the configured limit.
 //
 // The first call to return a non-nil error cancels the group's context, if the
 // group was created by calling WithContext. The error will be returned by Wait.
-func (g *Group) Go(f func() error) {
+func (g *Group) Go(f func() error, ph ...func()) {
 	if g.sem != nil {
 		g.sem <- token{}
 	}
 
 	g.wg.Add(1)
 	go func() {
+		defer func() {
+			if len(ph) > 0 && ph[0] != nil {
+				if r := recover(); r != nil {
+					ph[0]()
+				}
+			}
+		}()
+
 		defer g.done()
 
 		if err := f(); err != nil {
@@ -86,11 +89,10 @@ func (g *Group) Go(f func() error) {
 	}()
 }
 
-// TryGo calls the given function in a new goroutine only if the number of
-// active goroutines in the group is currently below the configured limit.
+// TryGo calls the given function in a new goroutine only if the number of// active goroutines in the group is currently below the configured limit.
 //
 // The return value reports whether the goroutine was started.
-func (g *Group) TryGo(f func() error) bool {
+func (g *Group) TryGo(f func() error, ph ...func()) bool {
 	if g.sem != nil {
 		select {
 		case g.sem <- token{}:
@@ -102,6 +104,14 @@ func (g *Group) TryGo(f func() error) bool {
 
 	g.wg.Add(1)
 	go func() {
+		defer func() {
+			if len(ph) > 0 && ph[0] != nil {
+				if r := recover(); r != nil {
+					ph[0]()
+				}
+			}
+		}()
+
 		defer g.done()
 
 		if err := f(); err != nil {
@@ -116,11 +126,9 @@ func (g *Group) TryGo(f func() error) bool {
 	return true
 }
 
-// SetLimit limits the number of active goroutines in this group to at most n.
-// A negative value indicates no limit.
+// SetLimit limits the number of active goroutines in this group to at most n.// A negative value indicates no limit.
 //
-// Any subsequent call to the Go method will block until it can add an active
-// goroutine without exceeding the configured limit.
+// Any subsequent call to the Go method will block until it can add an active// goroutine without exceeding the configured limit.
 //
 // The limit must not be modified while any goroutines in the group are active.
 func (g *Group) SetLimit(n int) {


### PR DESCRIPTION
Context:

Currently, whenever a goroutine is spawned, code is redundantly written to handle recovery in case of a panic. This can be simplified by allowing an optional, variadic panic handler to be passed as an argument. If a handler is provided, it will manage the panic according to the given function. 

The panic handler is implemented as a variadic parameter to ensure backward compatibility with existing functionality.

Objectives:

- [x] Implement a variadic panic handler for all spawned goroutines.