### PR TITLE
Variadic panic handler

### DIFF
--- a/errgroup/errgroup.go
+++ b/errgroup/errgroup.go
@@ -102,7 +102,7 @@ func (g *Group) TryGo(f func() error, ph ...func()) bool {
 	if g.sem != nil {
 		select {
 		case g.sem <- token{}:
-			// Note: this allows barging iff channels in general allow barging.
+			// Note: this allows barging if channels in general allow barging.
 		default:
 			return false
 		}


### PR DESCRIPTION
Context:

Currently, whenever a goroutine is spawned, code is redundantly written to handle recovery in case of a panic. This can be simplified by allowing an optional, variadic panic handler to be passed as an argument. If a handler is provided, it will manage the panic according to the given function. 

The panic handler is implemented as a variadic parameter to ensure backward compatibility with existing functionality.

Objectives:

- [x] Implement a variadic panic handler for all spawned goroutines.