### PR TITLE
Optimization: Increase the concurrency efficiency of dochan

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -154,12 +154,11 @@ func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
 		}
 
 		g.mu.Lock()
-		defer g.mu.Unlock()
 		c.wg.Done()
 		if g.m[key] == c {
 			delete(g.m, key)
 		}
-
+		g.mu.Unlock()
 		if e, ok := c.err.(*panicError); ok {
 			// In order to prevent the waiting channels from being blocked forever,
 			// needs to ensure that this panic cannot be recovered.


### PR DESCRIPTION
In Singlelight, the function of mutex is to protect the atomic access of critical resources in the map. In the following optimization, after deleting the key of the map, the mutex can be released without being responsible for each chan

## Benchmark code

```go
type user struct {
	Name string
}

func BenchmarkSingleflight(b *testing.B) {
	group := singleflight.Group{}
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			for i := 0; i < 1000; i++ {
				_ = <-group.DoChan(strconv.FormatInt(int64(i), 10), func() (inner interface{}, err error) {
					inner = user{
						Name: "hello",
					}
					return
				})
			}
		}
	})

}


```

## Before optimization

![企业微信截图_17325334374812](https://github.com/user-attachments/assets/2941c79a-f4f1-4806-9e77-a59d2b497b5f)

## Aftefter optimization

![企业微信截图_17325334761914](https://github.com/user-attachments/assets/28bb51e2-8f29-4124-9745-84dcc2af8452)


## summary

Overall, this has a significant performance improvement for singlelight, with an average increase of about 15% in time overhead