### PR TITLE
singleflight: Fix TestPanicErrorUnwrap

### DIFF
--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -19,14 +19,10 @@ import (
 	"time"
 )
 
-type errValue struct{}
-
-func (err *errValue) Error() string {
-	return "error value"
-}
-
 func TestPanicErrorUnwrap(t *testing.T) {
 	t.Parallel()
+
+	errValue := errors.New("error value")
 
 	testCases := []struct {
 		name             string
@@ -35,19 +31,17 @@ func TestPanicErrorUnwrap(t *testing.T) {
 	}{
 		{
 			name:             "panicError wraps non-error type",
-			panicValue:       &panicError{value: "string value"},
+			panicValue:       "string value",
 			wrappedErrorType: false,
 		},
 		{
 			name:             "panicError wraps error type",
-			panicValue:       &panicError{value: new(errValue)},
-			wrappedErrorType: false,
+			panicValue:       errValue,
+			wrappedErrorType: true,
 		},
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -75,8 +69,8 @@ func TestPanicErrorUnwrap(t *testing.T) {
 				t.Fatalf("recovered non-error type: %T", recovered)
 			}
 
-			if !errors.Is(err, new(errValue)) && tc.wrappedErrorType {
-				t.Errorf("unexpected wrapped error type %T; want %T", err, new(errValue))
+			if !errors.Is(err, errValue) && tc.wrappedErrorType {
+				t.Errorf("unexpected wrapped error \"%v\"; want \"%v\"", err, errValue)
 			}
 		})
 	}


### PR DESCRIPTION
TestPanicErrorUnwrap does not test what it seems to test

- "wrappedErrorType" is always false (should be true in the second case)
- The values are already wrapped in the private error (they shouldn't)
- "errors.Is(err, new(T))" is undefined for zero-sized "T"s (and false for non-zero-sized).
- "tc := tc" is not needed since Go 1.22

Fixes:

- Use a (local) sentinel value instead of a type, as in TestDoErr.
- Replace all "new(errValue)" by direct references to the unique sentinel "errValue".
- Replace diagnostic, since the error type we get is internal, so we can't directly expect that - it should only wrap our sentinel.

See my blog post at https://blog.fillmore-labs.com/posts/zerosized-2/ for a extended discussion.

Found by zerolint https://github.com/fillmore-labs/zerolint